### PR TITLE
feat: add option to skip version bump

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,10 @@ inputs:
     description: "Test the templating of staging values"
     required: false
     default: "true"
+  skip-version-bump-check:
+    description: "Skip checking for a version bump"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -92,10 +96,21 @@ runs:
 
     - name: Run Chart Linting Test
       shell: bash
+      if: ${{ inputs.skip-version-bump-check == 'true' }}
       run: ct lint
       env:
         CT_CHART_DIRS: charts
         CT_VALIDATE_MAINTAINERS: false
+        CT_TARGET_BRANCH: ${{ inputs.default-branch }}
+
+    - name: Run Chart Linting Test (skip version bump)
+      shell: bash
+      if: ${{ inputs.skip-version-bump-check == 'false' }}
+      run: ct lint
+      env:
+        CT_CHART_DIRS: charts
+        CT_VALIDATE_MAINTAINERS: false
+        CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
 
     - name: Update Chart Dependencies


### PR DESCRIPTION
## Description

Just adding a option to allow skipping the version bump check.
This will allow linting to run on a pr that uses auto versioning.
Currently this cant happen, because the version bump would be after the pr merge.

## Related Issue(s)

- <https://uxi.atlassian.net/browse/BEP-XXX>
