### PR TITLE
feat: lint environment specific values files

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ runs:
 
     - name: Setup Chart Testing Tool
       if: ${{ inputs.skip-helm-setup == 'false' }}
-      uses: helm/chart-testing-action@v2.3.1
+      uses: helm/chart-testing-action@v2.6.1
 
     - name: Configure AWS Credentials
       if: ${{ inputs.skip-aws-setup == 'false' }}
@@ -94,20 +94,39 @@ runs:
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
 
-    - name: Run Chart Linting Test (skip version bump)
+    - name: Run Production Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint
+      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:
         CT_CHART_DIRS: charts
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
 
-    - name: Run Chart Linting Test
+    - name: Run Production Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint
+      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      env:
+        CT_CHART_DIRS: charts
+        CT_VALIDATE_MAINTAINERS: false
+        CT_TARGET_BRANCH: ${{ inputs.default-branch }}
+
+    - name: Run Staging Chart Linting Test (skip version bump)
+      shell: bash
+      if: ${{ inputs.skip-version-bump-check == 'true' }}
+      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      env:
+        CT_CHART_DIRS: charts
+        CT_VALIDATE_MAINTAINERS: false
+        CT_CHECK_VERSION_INCREMENT: false
+        CT_TARGET_BRANCH: ${{ inputs.default-branch }}
+
+    - name: Run Staging Chart Linting Test
+      shell: bash
+      if: ${{ inputs.skip-version-bump-check == 'false' }}
+      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
         CT_CHART_DIRS: charts
         CT_VALIDATE_MAINTAINERS: false


### PR DESCRIPTION
## Description

`ct lint` does not take the environment specific values files into account when linting the charts. This becomes a problem when certain `required` environment specific fields are only specified in the `values-production.yaml` and `values-staging.yaml` files. IE:  `environment: "production"`. This is particularly an issue when additional templates are introduced

This PR passes an additional argument to `helm lint` to specify that a the environment specific values files should be used as well.
