### PR TITLE
fix: remove chart templating and dependency updating

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -105,7 +105,7 @@ runs:
       if: ${{ inputs.skip-version-bump-check == 'true' }}
       run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:
-        CT_CHART_DIRS: charts
+        CT_CHART_DIRS: ${{inputs.chart-directory}}
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -115,7 +115,7 @@ runs:
       if: ${{ inputs.skip-version-bump-check == 'false' }}
       run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:
-        CT_CHART_DIRS: charts
+        CT_CHART_DIRS: ${{inputs.chart-directory}}
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
 
@@ -124,7 +124,7 @@ runs:
       if: ${{ inputs.skip-version-bump-check == 'true' }}
       run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
-        CT_CHART_DIRS: charts
+        CT_CHART_DIRS: ${{inputs.chart-directory}}
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -134,6 +134,6 @@ runs:
       if: ${{ inputs.skip-version-bump-check == 'false' }}
       run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
-        CT_CHART_DIRS: charts
+        CT_CHART_DIRS: ${{inputs.chart-directory}}
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -102,9 +102,8 @@ runs:
     - name: Run Production Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
-      env:
-        CT_CHART_DIRS: ${{inputs.chart-directory}}
+      run: ct lint --charts ${{inputs.chart-directory}} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -112,18 +111,16 @@ runs:
     - name: Run Production Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
-      env:
-        CT_CHART_DIRS: ${{inputs.chart-directory}}
+      run: ct lint --charts ${{inputs.chart-directory}} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
 
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
-      env:
-        CT_CHART_DIRS: ${{inputs.chart-directory}}
+      run: ct lint --charts ${{inputs.chart-directory}} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      env:       
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -131,8 +128,7 @@ runs:
     - name: Run Staging Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts ${{inputs.chart-directory}} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
-        CT_CHART_DIRS: ${{inputs.chart-directory}}
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -81,11 +81,6 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
 
-    # - name: Update Chart Dependencies
-    #   shell: bash
-    #   run: |        
-    #     helm dependency update ${{ inputs.chart-directory }}
-
     - name: Run Chart Changes Test
       id: list-changed
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -118,7 +118,7 @@ runs:
       
     - name: Remove Chart.lock
       shell: bash
-      run: rm ${{ inputs.chart-directory }}/Chart.lock
+      run: rm -f ${{ inputs.chart-directory }}/Chart.lock
 
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
       run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment false --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-production.yaml'
-      env:        
+      env:
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -107,10 +107,10 @@ runs:
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
       run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-production.yaml'
-      env:        
+      env:
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
-      
+
     - name: Remove Chart.lock
       shell: bash
       run: rm -f ${{ inputs.chart-directory }}/Chart.lock
@@ -119,7 +119,7 @@ runs:
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
       run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment false --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-staging.yaml'
-      env:       
+      env:
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -81,10 +81,10 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
 
-    - name: Update Chart Dependencies
-      shell: bash
-      run: |        
-        helm dependency update ${{ inputs.chart-directory }}
+    # - name: Update Chart Dependencies
+    #   shell: bash
+    #   run: |        
+    #     helm dependency update ${{ inputs.chart-directory }}
 
     - name: Run Chart Changes Test
       id: list-changed

--- a/action.yaml
+++ b/action.yaml
@@ -102,7 +102,7 @@ runs:
     - name: Run Production Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts charts --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -111,7 +111,7 @@ runs:
     - name: Run Production Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts charts --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -119,7 +119,7 @@ runs:
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts charts --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:       
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -128,7 +128,7 @@ runs:
     - name: Run Staging Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts charts --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -102,7 +102,7 @@ runs:
     - name: Run Production Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment false --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -111,7 +111,7 @@ runs:
     - name: Run Production Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -123,7 +123,7 @@ runs:
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment false --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-staging.yaml'
       env:       
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -132,7 +132,7 @@ runs:
     - name: Run Staging Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts ${{ inputs.chart-directory }} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts ${{ inputs.chart-directory }} --helm-lint-extra-args '-f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -102,7 +102,7 @@ runs:
     - name: Run Production Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts ${{inputs.chart-directory}} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts charts --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -111,7 +111,7 @@ runs:
     - name: Run Production Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts ${{inputs.chart-directory}} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
+      run: ct lint --charts charts --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-production.yaml'
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
@@ -119,7 +119,7 @@ runs:
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'true' }}
-      run: ct lint --charts ${{inputs.chart-directory}} --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts charts --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:       
         CT_VALIDATE_MAINTAINERS: false
         CT_CHECK_VERSION_INCREMENT: false
@@ -128,7 +128,7 @@ runs:
     - name: Run Staging Chart Linting Test
       shell: bash
       if: ${{ inputs.skip-version-bump-check == 'false' }}
-      run: ct lint --charts ${{inputs.chart-directory}} --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
+      run: ct lint --charts charts --check-version-increment true --helm-lint-extra-args '--values ${{ inputs.chart-directory }}/values-staging.yaml'
       env:
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -137,18 +137,3 @@ runs:
         CT_CHART_DIRS: charts
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
-
-    - name: Template Production Charts
-      shell: bash
-      if: ${{ inputs.test-production == 'true' }}
-      run: helm template ${{ inputs.deployment-name }} ${{ inputs.chart-directory }} -n ${{ inputs.deployment-name }} -f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-production.yaml
-
-    - name: Template Staging Charts
-      shell: bash
-      if: ${{ inputs.test-staging == 'true' }}
-      run: helm template ${{ inputs.deployment-name }} ${{ inputs.chart-directory }} -n ${{ inputs.deployment-name }} -f ${{ inputs.chart-directory }}/values.yaml -f ${{ inputs.chart-directory }}/values-staging.yaml
-
-    - name: Template Local Charts
-      shell: bash
-      if: ${{ inputs.test-local == 'true' }}
-      run: helm template ${{ inputs.deployment-name }} ${{ inputs.chart-directory }} -n ${{ inputs.deployment-name }} -f ${{ inputs.chart-directory }}/values.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -115,6 +115,10 @@ runs:
       env:        
         CT_VALIDATE_MAINTAINERS: false
         CT_TARGET_BRANCH: ${{ inputs.default-branch }}
+      
+    - name: Remove Chart.lock
+      shell: bash
+      run: rm ${{ inputs.chart-directory }}/Chart.lock
 
     - name: Run Staging Chart Linting Test (skip version bump)
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -83,8 +83,7 @@ runs:
 
     - name: Update Chart Dependencies
       shell: bash
-      run: |
-        helm repo add aruba-uxi s3://hpe-uxi-helm-repo
+      run: |        
         helm dependency update ${{ inputs.chart-directory }}
 
     - name: Run Chart Changes Test


### PR DESCRIPTION
## Description

- remove chart templating because we are no linting the values files as well
- remove helm dependency update because it was creating a Chart.lock file that was breaking things
